### PR TITLE
Solved the Breadcrumbs issue

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) [2017] Viral Solani [viral.solani@gmail.com]
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # laravel-adminpanel
+
+### License
+
+MIT: Look at [LICENSE.txt](https://github.com/bvipul/laravel-adminpanel/blob/master/README.md)

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 ### License
 
-MIT: Look at [LICENSE.txt](https://github.com/bvipul/laravel-adminpanel/blob/master/README.md)
+[MIT LICENSE](https://github.com/bvipul/laravel-adminpanel/blob/vs_license/LICENSE.txt)

--- a/app/Http/Breadcrumbs/Backend/Backend.php
+++ b/app/Http/Breadcrumbs/Backend/Backend.php
@@ -16,4 +16,5 @@ require __DIR__.'/Blog_Tag.php';
 require __DIR__.'/Blog_Management.php';
 require __DIR__.'/Faqs.php';
 require __DIR__.'/Module.php';
+require __DIR__.'/Menu.php';
 require __DIR__.'/LogViewer.php';

--- a/app/Http/Breadcrumbs/Backend/Menu.php
+++ b/app/Http/Breadcrumbs/Backend/Menu.php
@@ -1,0 +1,16 @@
+<?php
+
+Breadcrumbs::register('admin.menus.index', function ($breadcrumbs) {
+    $breadcrumbs->parent('admin.dashboard');
+    $breadcrumbs->push(trans('menus.backend.menus.management'), route('admin.menus.index'));
+});
+
+Breadcrumbs::register('admin.menus.create', function ($breadcrumbs) {
+    $breadcrumbs->parent('admin.menus.index');
+    $breadcrumbs->push(trans('menus.backend.menus.create'), route('admin.menus.create'));
+});
+
+Breadcrumbs::register('admin.menus.edit', function ($breadcrumbs, $id) {
+    $breadcrumbs->parent('admin.menus.index');
+    $breadcrumbs->push(trans('menus.backend.menus.edit'), route('admin.menus.edit', $id));
+});

--- a/app/Http/breadcrumbs.php
+++ b/app/Http/breadcrumbs.php
@@ -1,3 +1,0 @@
-<?php
-
-require __DIR__.'/Breadcrumbs/Backend/Backend.php';

--- a/resources/views/backend/includes/partials/breadcrumbs.blade.php
+++ b/resources/views/backend/includes/partials/breadcrumbs.blade.php
@@ -1,7 +1,7 @@
 @if ($breadcrumbs)
     <ol class="breadcrumb">
         @foreach ($breadcrumbs as $breadcrumb)
-            @if (!$breadcrumb->last)
+            @if ($breadcrumb->url && !$loop->last)
                 <li><a href="{{ $breadcrumb->url }}">{{ $breadcrumb->title }}</a></li>
             @else
                 <li class="active">{{ $breadcrumb->title }}</li>

--- a/resources/views/backend/layouts/app.blade.php
+++ b/resources/views/backend/layouts/app.blade.php
@@ -58,9 +58,8 @@
                 <!-- Content Header (Page header) -->
                 <section class="content-header">
                     @yield('page-header')
-
-                    {{-- Change to Breadcrumbs::render() if you want it to error to remind you to create the breadcrumbs for the given route --}}
-                  {{--   {!! Breadcrumbs::render() !!} --}}
+                    <!-- Breadcrumbs would render from routes/breadcrumb.php -->
+                    {!! Breadcrumbs::render() !!}
                 </section>
 
                 <!-- Main content -->

--- a/routes/breadcrumbs.php
+++ b/routes/breadcrumbs.php
@@ -1,0 +1,3 @@
+<?php
+//Just pointed it to where the breadcrumbs are located, in Http/Breadcrumbs/Backend
+require __DIR__.'/../app/Http/Breadcrumbs/Backend/Backend.php';


### PR DESCRIPTION
Actually, the package has updated and the breadcrumbs.php (which contains all the breadcrumbs) now should be in routes/ folder.
And a little change in the breadcrumb render file with new method on the official documentation.