### PR TITLE
Fixed error on registration page caused by wrong route name

### DIFF
--- a/resources/views/frontend/auth/register.blade.php
+++ b/resources/views/frontend/auth/register.blade.php
@@ -51,7 +51,7 @@
                             <div class="col-xs-7">
                                <label class="col-md-12 control-label">
                                  {!! Form::checkbox('is_term_accept',1,false) !!}
-                                 I accept {!! link_to_route('frontend.cmspages.show', trans('validation.attributes.frontend.register-user.terms_and_conditions').'*', ['page_slug'=>'terms-and-conditions']) !!} </label>
+                                 I accept {!! link_to_route('frontend.pages.show', trans('validation.attributes.frontend.register-user.terms_and_conditions').'*', ['page_slug'=>'terms-and-conditions']) !!} </label>
 
                          </div><!--form-group-->
                     </div><!--col-md-6-->


### PR DESCRIPTION
Fixed error on registration page caused by wrong route name in resources/views/frontend/auth/register.blade.php